### PR TITLE
feat: make deepsearch-toolkit optional

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
       run: poetry build
     - name: Testing
       run: |
-        poetry install --with test
+        poetry install --with test --all-extras
         #poetry run pytest ./tests/test_nlp.py -vvv -s
         poetry run pytest ./tests/test_structs.py -v
         poetry run pytest ./tests/test_nlp.py -v	

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -103,7 +103,7 @@ jobs:
         run: |
           echo "Building wheel ${CIBW_BUILD}"
           poetry run python --version
-          poetry install
+          poetry install --all-extras
           cat ./pyproject.toml
           poetry run python -m cibuildwheel --output-dir wheelhouse
           echo "step 1"
@@ -140,7 +140,7 @@ jobs:
         run: |
           echo "Building wheel ${CIBW_BUILD}"
           poetry run python --version
-          poetry install
+          poetry install --all-extras
           cat ./pyproject.toml
           poetry run python -m cibuildwheel --output-dir wheelhouse
           echo "step 1"

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ To use the python interface, first make sure all dependencies are installed. We 
 for that. To install all the dependent python packages and get the python bindings, simply execute,
 
 ```sh
-poetry install
+poetry install --all-extras
 ```
 
 ### CXX compilation
@@ -161,6 +161,8 @@ cmake --build ./build -j
 
 ### NLP and GLM examples
 
+_Note: Some of the examples require to convert PDF documents with Deep Search. For this to run, it is required to install the [deepsearch-toolkit](https://github.com/DS4SD/deepsearch-toolkit) package. You can install it with `pip install deepsearch-glm[toolkit]`._
+
 To run the examples, simply do execute the scripts as `poetry run python <script> <input>`. Examples are,
 
 1. **apply NLP on document(s)**
@@ -177,6 +179,10 @@ poetry run python ./deepsearch_glm/glm_create_from_docs.py --pdf ./data/document
 ```
 
 ### Deep Search utilities
+
+To use the Deep Search capabilities, it is required to install the [deepsearch-toolkit](https://github.com/DS4SD/deepsearch-toolkit) package.
+You can install it with `pip install deepsearch-glm[toolkit]`.
+
 
 1. **Query and download document(s)**
 ```sh

--- a/deepsearch_glm/glm_utils.py
+++ b/deepsearch_glm/glm_utils.py
@@ -14,7 +14,7 @@ import pandas as pd
 from tabulate import tabulate
 
 from deepsearch_glm.andromeda_glm import glm_model, glm_query
-from deepsearch_glm.utils.ds_utils import get_scratch_dir
+from deepsearch_glm.utils.common import get_scratch_dir
 
 
 def create_glm_dir():

--- a/deepsearch_glm/nlp_apply_on_docs.py
+++ b/deepsearch_glm/nlp_apply_on_docs.py
@@ -12,11 +12,8 @@ import pandas as pd
 from tabulate import tabulate
 
 from deepsearch_glm.andromeda_nlp import nlp_model
-from deepsearch_glm.utils.ds_utils import (
-    convert_pdffiles,
-    to_legacy_document_format,
-    to_xml_format,
-)
+from deepsearch_glm.utils.doc_utils import to_legacy_document_format, to_xml_format
+from deepsearch_glm.utils.ds_utils import convert_pdffiles
 
 
 def parse_arguments():

--- a/deepsearch_glm/nlp_model_training/reference_parsing.py
+++ b/deepsearch_glm/nlp_model_training/reference_parsing.py
@@ -11,8 +11,8 @@ import sys
 import time
 
 import pandas as pd
-import textColor as tc
 import tqdm
+from rich import Console
 from tabulate import tabulate
 
 # from deepsearch_glm.andromeda_nlp import nlp_model
@@ -23,6 +23,8 @@ from deepsearch_glm.nlp_utils import (
     train_crf,
 )
 from deepsearch_glm.utils.load_pretrained_models import get_resources_dir
+
+console = Console()
 
 
 def parse_arguments():
@@ -230,8 +232,8 @@ def parse_with_anystyle_api(anystyle, refs):
 
         return tmp
     except Exception as exc:
-        print(tc.red("could not call anystyle API endpoint ..."))
-        print(tc.yellow(f" -> error: {str(exc)}"))
+        console.print("could not call anystyle API endpoint ...", style="red")
+        console.print(f" -> error: {str(exc)}", style="yellow")
 
     if os.path.exists(tmpfile):
         os.remove(tmpfile)

--- a/deepsearch_glm/nlp_model_training/semantic_classifier.py
+++ b/deepsearch_glm/nlp_model_training/semantic_classifier.py
@@ -9,13 +9,15 @@ import random
 import sys
 
 import pandas as pd
-import textColor as tc
 import tqdm
+from rich.console import Console
 from tabulate import tabulate
 
 from deepsearch_glm.andromeda_nlp import nlp_model
 from deepsearch_glm.nlp_utils import create_nlp_dir, init_nlp_model
 from deepsearch_glm.utils.ds_utils import ds_index_query
+
+console = Console()
 
 
 def parse_arguments():
@@ -231,15 +233,15 @@ def prepare_data_from_legacy_documents(doc):
             label = "text"
 
         if "title" in label:
-            print(tc.yellow(f"{label}, {type_}: {text[0:48]}"))
+            console.print(f"{label}, {type_}: {text[0:48]}", style="yellow")
         elif "meta" in label:
-            print(tc.green(f"\t{label}, {type_}: {text[0:48]}"))
+            console.print(f"\t{label}, {type_}: {text[0:48]}", style="green")
         elif "text" in label:
-            print(f"\t{label}, {type_}: {text[0:48]}")
+            console.print(f"\t{label}, {type_}: {text[0:48]}")
         elif "reference" in label:
-            print(tc.blue(f"\t{label}, {type_}: {text[0:48]}"))
+            console.print(f"\t{label}, {type_}: {text[0:48]}", style="blue")
         else:
-            print(tc.red(f"\t{label}, {type_}: {text[0:48]}"))
+            console.print(f"\t{label}, {type_}: {text[0:48]}", style="red")
 
         if random.random() < 0.9:
             training_sample = True

--- a/deepsearch_glm/nlp_utils.py
+++ b/deepsearch_glm/nlp_utils.py
@@ -14,13 +14,16 @@ import textwrap
 from typing import List
 
 import pandas as pd
-import textColor as tc
+from rich.console import Console
 from tabulate import tabulate
 
 from deepsearch_glm.andromeda_nlp import nlp_model
 from deepsearch_glm.utils.common import get_scratch_dir
 
 # import andromeda_nlp
+
+
+console = Console()
 
 
 def create_nlp_dir(tdir=None):
@@ -102,25 +105,28 @@ def print_key_on_shell(key, items):
             table.append(_)
 
         headers = ["type", "subtype", "subj_path", "char_i", "char_j", "original"]
-        print(tc.yellow(f"{key}: \n\n"), tabulate(table, headers=headers), "\n")
+        console.print(f"{key}: \n", style="yellow")
+        console.print(tabulate(table, headers=headers), "\n")
 
     else:
         df = pd.DataFrame(items["data"], columns=items["headers"])
 
-        print(tc.yellow(f"{key}: \n\n"), df.to_string(), "\n")
+        console.print(f"{key}: \n", style="yellow")
+        console.print(df.to_string(), "\n")
 
 
 def print_on_shell(text, result):
     """Function to print text on shell"""
 
     wrapper = textwrap.TextWrapper(width=70)
-    print(tc.yellow(f"\ntext: \n\n"), "\n".join(wrapper.wrap(text)), "\n")
+    console.print(f"\ntext: \n", style="yellow")
+    console.print("\n".join(wrapper.wrap(text)), "\n")
 
     for _ in ["properties", "word-tokens", "instances", "entities", "relations"]:
         if _ in result and len(result[_]["data"]) > 0:
             print_key_on_shell(_, result[_])
         else:
-            print(tc.yellow(f"{_}:"), " null\n\n")
+            console.print(f"[yellow]{_}:[/yellow]", " null\n\n")
 
 
 def extract_metadata_from_doc(doc):

--- a/deepsearch_glm/nlp_utils.py
+++ b/deepsearch_glm/nlp_utils.py
@@ -18,7 +18,7 @@ import textColor as tc
 from tabulate import tabulate
 
 from deepsearch_glm.andromeda_nlp import nlp_model
-from deepsearch_glm.utils.ds_utils import get_scratch_dir
+from deepsearch_glm.utils.common import get_scratch_dir
 
 # import andromeda_nlp
 

--- a/deepsearch_glm/utils/common.py
+++ b/deepsearch_glm/utils/common.py
@@ -1,0 +1,16 @@
+import os
+
+from dotenv import load_dotenv
+
+
+def get_scratch_dir():
+    """Get scratch directory from environment variable `DEEPSEARCH_GLM_SCRATCH_DIR` (defined in .env)"""
+
+    load_dotenv()
+
+    tmpdir = os.path.abspath(os.getenv("DEEPSEARCH_GLM_SCRATCH_DIR"))
+
+    if not os.path.exists(tmpdir):
+        os.mkdir(tmpdir)
+
+    return tmpdir

--- a/deepsearch_glm/utils/doc_utils.py
+++ b/deepsearch_glm/utils/doc_utils.py
@@ -1,0 +1,315 @@
+import re
+
+import pandas as pd
+
+
+def resolve_item(paths, obj):
+    """Find item in document from a reference path"""
+
+    if len(paths) == 0:
+        return obj
+
+    if paths[0] == "#":
+        return resolve_item(paths[1:], obj)
+
+    try:
+        key = int(paths[0])
+    except:
+        key = paths[0]
+
+    if len(paths) == 1:
+        if isinstance(key, str) and key in obj:
+            return obj[key]
+        elif isinstance(key, int) and key < len(obj):
+            return obj[key]
+        else:
+            return None
+
+    elif len(paths) > 1:
+        if isinstance(key, str) and key in obj:
+            return resolve_item(paths[1:], obj[key])
+        elif isinstance(key, int) and key < len(obj):
+            return resolve_item(paths[1:], obj[key])
+        else:
+            return None
+
+    else:
+        return None
+
+
+def to_legacy_document_format(doc_glm, doc_leg={}, update_name_label=False):
+    """Convert Document object (with `body`) to its legacy format (with `main-text`)"""
+
+    doc_leg["main-text"] = []
+    doc_leg["figures"] = []
+    doc_leg["tables"] = []
+    doc_leg["page-headers"] = []
+    doc_leg["page-footers"] = []
+    doc_leg["footnotes"] = []
+    doc_leg["equations"] = []
+
+    if "properties" in doc_glm:
+        props = pd.DataFrame(
+            doc_glm["properties"]["data"], columns=doc_glm["properties"]["headers"]
+        )
+    else:
+        props = pd.DataFrame()
+
+    for pelem in doc_glm["page-elements"]:
+        ptype = pelem["type"]
+        span_i = pelem["span"][0]
+        span_j = pelem["span"][1]
+
+        if "iref" not in pelem:
+            # print(json.dumps(pelem, indent=2))
+            continue
+
+        iref = pelem["iref"]
+
+        if re.match("#/figures/(\\d+)/captions/(.+)", iref):
+            # print(f"skip {iref}")
+            continue
+
+        if re.match("#/tables/(\\d+)/captions/(.+)", iref):
+            # print(f"skip {iref}")
+            continue
+
+        path = iref.split("/")
+        obj = resolve_item(path, doc_glm)
+
+        if obj is None:
+            print(f"warning: undefined {path}")
+            continue
+
+        if ptype == "figure":
+            text = ""
+            for caption in obj["captions"]:
+                text += caption["text"]
+
+                for nprov in caption["prov"]:
+                    npaths = nprov["$ref"].split("/")
+                    nelem = resolve_item(npaths, doc_glm)
+
+                    if nelem is None:
+                        print(f"warning: undefined caption {npaths}")
+                        continue
+
+                    span_i = nelem["span"][0]
+                    span_j = nelem["span"][1]
+
+                    text = caption["text"][span_i:span_j]
+
+                    pitem = {
+                        "text": text,
+                        "name": nelem["name"],
+                        "type": nelem["type"],
+                        "prov": [
+                            {
+                                "bbox": nelem["bbox"],
+                                "page": nelem["page"],
+                                "span": [0, len(text)],
+                            }
+                        ],
+                    }
+                    doc_leg["main-text"].append(pitem)
+
+            find = len(doc_leg["figures"])
+
+            figure = {
+                "confidence": obj.get("confidence", 0),
+                "created_by": obj.get("created_by", ""),
+                "type": obj.get("type", "figure"),
+                "cells": [],
+                "data": [],
+                "text": text,
+                "prov": [
+                    {
+                        "bbox": pelem["bbox"],
+                        "page": pelem["page"],
+                        "span": [0, len(text)],
+                    }
+                ],
+            }
+            doc_leg["figures"].append(figure)
+
+            pitem = {
+                "$ref": f"#/figures/{find}",
+                "name": pelem["name"],
+                "type": pelem["type"],
+            }
+            doc_leg["main-text"].append(pitem)
+
+        elif ptype == "table":
+            text = ""
+            for caption in obj["captions"]:
+                text += caption["text"]
+
+                for nprov in caption["prov"]:
+                    npaths = nprov["$ref"].split("/")
+                    nelem = resolve_item(npaths, doc_glm)
+
+                    if nelem is None:
+                        print(f"warning: undefined caption {npaths}")
+                        continue
+
+                    span_i = nelem["span"][0]
+                    span_j = nelem["span"][1]
+
+                    text = caption["text"][span_i:span_j]
+
+                    pitem = {
+                        "text": text,
+                        "name": nelem["name"],
+                        "type": nelem["type"],
+                        "prov": [
+                            {
+                                "bbox": nelem["bbox"],
+                                "page": nelem["page"],
+                                "span": [0, len(text)],
+                            }
+                        ],
+                    }
+                    doc_leg["main-text"].append(pitem)
+
+            tind = len(doc_leg["tables"])
+
+            table = {
+                "#-cols": obj.get("#-cols", 0),
+                "#-rows": obj.get("#-rows", 0),
+                "confidence": obj.get("confidence", 0),
+                "created_by": obj.get("created_by", ""),
+                "type": obj.get("type", "table"),
+                "cells": [],
+                "data": obj["data"],
+                "text": text,
+                "prov": [
+                    {"bbox": pelem["bbox"], "page": pelem["page"], "span": [0, 0]}
+                ],
+            }
+            doc_leg["tables"].append(table)
+
+            pitem = {
+                "$ref": f"#/tables/{tind}",
+                "name": pelem["name"],
+                "type": pelem["type"],
+            }
+            doc_leg["main-text"].append(pitem)
+
+        elif "text" in obj:
+            text = obj["text"][span_i:span_j]
+
+            type_label = pelem["type"]
+            name_label = pelem["name"]
+            if update_name_label and len(props) > 0 and type_label == "paragraph":
+                prop = props[
+                    (props["type"] == "semantic") & (props["subj_path"] == iref)
+                ]
+                if len(prop) == 1 and prop.iloc[0]["confidence"] > 0.85:
+                    name_label = prop.iloc[0]["label"]
+
+            pitem = {
+                "text": text,
+                "name": name_label,  # pelem["name"],
+                "type": type_label,  # pelem["type"],
+                "prov": [
+                    {
+                        "bbox": pelem["bbox"],
+                        "page": pelem["page"],
+                        "span": [0, len(text)],
+                    }
+                ],
+            }
+            doc_leg["main-text"].append(pitem)
+
+        else:
+            pitem = {
+                "name": pelem["name"],
+                "type": pelem["type"],
+                "prov": [
+                    {"bbox": pelem["bbox"], "page": pelem["page"], "span": [0, 0]}
+                ],
+            }
+            doc_leg["main-text"].append(pitem)
+
+    return doc_leg
+
+
+def to_xml_format(doc_glm, normalised_pagedim: int = -1):
+    result = "<document>\n"
+
+    page_dims = pd.DataFrame()
+    if "page-dimensions":
+        page_dims = pd.DataFrame(doc_glm["page-dimensions"])
+
+    for pelem in doc_glm["page-elements"]:
+        ptype = pelem["type"]
+        span_i = pelem["span"][0]
+        span_j = pelem["span"][1]
+
+        if "iref" not in pelem:
+            # print(json.dumps(pelem, indent=2))
+            continue
+
+        iref = pelem["iref"]
+
+        page = pelem["page"]
+        bbox = pelem["bbox"]
+
+        x0 = bbox[0]
+        y0 = bbox[1]
+        x1 = bbox[2]
+        y1 = bbox[3]
+
+        if normalised_pagedim > 0 and len(page_dims[page_dims["page"] == page]) > 0:
+            page_width = page_dims[page_dims["page"] == page].iloc[0]["width"]
+            page_height = page_dims[page_dims["page"] == page].iloc[0]["height"]
+
+            rx0 = float(x0) / float(page_width) * normalised_pagedim
+            rx1 = float(x1) / float(page_width) * normalised_pagedim
+
+            ry0 = float(y0) / float(page_height) * normalised_pagedim
+            ry1 = float(y1) / float(page_height) * normalised_pagedim
+
+            x0 = max(0, min(normalised_pagedim, round(rx0)))
+            x1 = max(0, min(normalised_pagedim, round(rx1)))
+
+            y0 = max(0, min(normalised_pagedim, round(ry0)))
+            y1 = max(0, min(normalised_pagedim, round(ry1)))
+
+        elif normalised_pagedim > 0 and len(page_dims[page_dims["page"] == page]) == 0:
+            print(f"ERROR: no page dimensions for page {page}")
+
+        if re.match("#/figures/(\\d+)/captions/(.+)", iref):
+            # print(f"skip {iref}")
+            continue
+
+        if re.match("#/tables/(\\d+)/captions/(.+)", iref):
+            # print(f"skip {iref}")
+            continue
+
+        path = iref.split("/")
+        obj = resolve_item(path, doc_glm)
+
+        if obj is None:
+            print(f"warning: undefined {path}")
+            continue
+
+        if ptype == "figure":
+            result += f"<figure bbox=[{x0}, {y0}, {x1}, {y1}]></figure>\n"
+
+        elif ptype == "table":
+            result += f"<table bbox=[{x0}, {y0}, {x1}, {y1}]></table>\n"
+
+        elif "text" in obj:
+            text = obj["text"][span_i:span_j]
+            text_type = pelem["type"]
+
+            result += (
+                f"<{text_type} bbox=[{x0}, {y0}, {x1}, {y1}]>{text}</{text_type}>\n"
+            )
+        else:
+            continue
+
+    result += "</document>"
+
+    return result

--- a/deepsearch_glm/utils/ds_utils.py
+++ b/deepsearch_glm/utils/ds_utils.py
@@ -6,11 +6,19 @@ import glob
 import hashlib
 import json
 import os
-import re
 import subprocess
 
-import deepsearch as ds
-import pandas as pd
+from deepsearch_glm.utils.common import get_scratch_dir
+
+try:
+    import deepsearch as ds
+except ImportError as err:
+    raise ImportError(
+        "To use the Deep Search capabilities, it is required to install the deepsearch-toolkit package."
+        "You can install it with `pip install deepsearch-toolkit` or using the convenience extra in "
+        "deepsearch-glm as `pip install deepsearch-glm[toolkit]`."
+    ) from None
+
 from deepsearch.cps.client.components.elastic import ElasticDataCollectionSource
 
 # from deepsearch.cps.client.components.queries import RunQueryError
@@ -19,18 +27,12 @@ from dotenv import load_dotenv
 from numerize.numerize import numerize
 from tqdm import tqdm
 
-
-def get_scratch_dir():
-    """Get scratch directory from environment variable `DEEPSEARCH_GLM_SCRATCH_DIR` (defined in .env)"""
-
-    load_dotenv()
-
-    tmpdir = os.path.abspath(os.getenv("DEEPSEARCH_GLM_SCRATCH_DIR"))
-
-    if not os.path.exists(tmpdir):
-        os.mkdir(tmpdir)
-
-    return tmpdir
+# re-import from the new module, in order to keep backwards compatibility
+from deepsearch_glm.utils.doc_utils import (
+    resolve_item,
+    to_legacy_document_format,
+    to_xml_format,
+)
 
 
 def load_vars():
@@ -294,315 +296,3 @@ def ds_index_query(
             break
 
     return dumpdir
-
-
-def resolve_item(paths, obj):
-    """Find item in document from a reference path"""
-
-    if len(paths) == 0:
-        return obj
-
-    if paths[0] == "#":
-        return resolve_item(paths[1:], obj)
-
-    try:
-        key = int(paths[0])
-    except:
-        key = paths[0]
-
-    if len(paths) == 1:
-        if isinstance(key, str) and key in obj:
-            return obj[key]
-        elif isinstance(key, int) and key < len(obj):
-            return obj[key]
-        else:
-            return None
-
-    elif len(paths) > 1:
-        if isinstance(key, str) and key in obj:
-            return resolve_item(paths[1:], obj[key])
-        elif isinstance(key, int) and key < len(obj):
-            return resolve_item(paths[1:], obj[key])
-        else:
-            return None
-
-    else:
-        return None
-
-
-def to_legacy_document_format(doc_glm, doc_leg={}, update_name_label=False):
-    """Convert Document object (with `body`) to its legacy format (with `main-text`)"""
-
-    doc_leg["main-text"] = []
-    doc_leg["figures"] = []
-    doc_leg["tables"] = []
-    doc_leg["page-headers"] = []
-    doc_leg["page-footers"] = []
-    doc_leg["footnotes"] = []
-    doc_leg["equations"] = []
-
-    if "properties" in doc_glm:
-        props = pd.DataFrame(
-            doc_glm["properties"]["data"], columns=doc_glm["properties"]["headers"]
-        )
-    else:
-        props = pd.DataFrame()
-
-    for pelem in doc_glm["page-elements"]:
-        ptype = pelem["type"]
-        span_i = pelem["span"][0]
-        span_j = pelem["span"][1]
-
-        if "iref" not in pelem:
-            # print(json.dumps(pelem, indent=2))
-            continue
-
-        iref = pelem["iref"]
-
-        if re.match("#/figures/(\\d+)/captions/(.+)", iref):
-            # print(f"skip {iref}")
-            continue
-
-        if re.match("#/tables/(\\d+)/captions/(.+)", iref):
-            # print(f"skip {iref}")
-            continue
-
-        path = iref.split("/")
-        obj = resolve_item(path, doc_glm)
-
-        if obj is None:
-            print(f"warning: undefined {path}")
-            continue
-
-        if ptype == "figure":
-            text = ""
-            for caption in obj["captions"]:
-                text += caption["text"]
-
-                for nprov in caption["prov"]:
-                    npaths = nprov["$ref"].split("/")
-                    nelem = resolve_item(npaths, doc_glm)
-
-                    if nelem is None:
-                        print(f"warning: undefined caption {npaths}")
-                        continue
-
-                    span_i = nelem["span"][0]
-                    span_j = nelem["span"][1]
-
-                    text = caption["text"][span_i:span_j]
-
-                    pitem = {
-                        "text": text,
-                        "name": nelem["name"],
-                        "type": nelem["type"],
-                        "prov": [
-                            {
-                                "bbox": nelem["bbox"],
-                                "page": nelem["page"],
-                                "span": [0, len(text)],
-                            }
-                        ],
-                    }
-                    doc_leg["main-text"].append(pitem)
-
-            find = len(doc_leg["figures"])
-
-            figure = {
-                "confidence": obj.get("confidence", 0),
-                "created_by": obj.get("created_by", ""),
-                "type": obj.get("type", "figure"),
-                "cells": [],
-                "data": [],
-                "text": text,
-                "prov": [
-                    {
-                        "bbox": pelem["bbox"],
-                        "page": pelem["page"],
-                        "span": [0, len(text)],
-                    }
-                ],
-            }
-            doc_leg["figures"].append(figure)
-
-            pitem = {
-                "$ref": f"#/figures/{find}",
-                "name": pelem["name"],
-                "type": pelem["type"],
-            }
-            doc_leg["main-text"].append(pitem)
-
-        elif ptype == "table":
-            text = ""
-            for caption in obj["captions"]:
-                text += caption["text"]
-
-                for nprov in caption["prov"]:
-                    npaths = nprov["$ref"].split("/")
-                    nelem = resolve_item(npaths, doc_glm)
-
-                    if nelem is None:
-                        print(f"warning: undefined caption {npaths}")
-                        continue
-
-                    span_i = nelem["span"][0]
-                    span_j = nelem["span"][1]
-
-                    text = caption["text"][span_i:span_j]
-
-                    pitem = {
-                        "text": text,
-                        "name": nelem["name"],
-                        "type": nelem["type"],
-                        "prov": [
-                            {
-                                "bbox": nelem["bbox"],
-                                "page": nelem["page"],
-                                "span": [0, len(text)],
-                            }
-                        ],
-                    }
-                    doc_leg["main-text"].append(pitem)
-
-            tind = len(doc_leg["tables"])
-
-            table = {
-                "#-cols": obj.get("#-cols", 0),
-                "#-rows": obj.get("#-rows", 0),
-                "confidence": obj.get("confidence", 0),
-                "created_by": obj.get("created_by", ""),
-                "type": obj.get("type", "table"),
-                "cells": [],
-                "data": obj["data"],
-                "text": text,
-                "prov": [
-                    {"bbox": pelem["bbox"], "page": pelem["page"], "span": [0, 0]}
-                ],
-            }
-            doc_leg["tables"].append(table)
-
-            pitem = {
-                "$ref": f"#/tables/{tind}",
-                "name": pelem["name"],
-                "type": pelem["type"],
-            }
-            doc_leg["main-text"].append(pitem)
-
-        elif "text" in obj:
-            text = obj["text"][span_i:span_j]
-
-            type_label = pelem["type"]
-            name_label = pelem["name"]
-            if update_name_label and len(props) > 0 and type_label == "paragraph":
-                prop = props[
-                    (props["type"] == "semantic") & (props["subj_path"] == iref)
-                ]
-                if len(prop) == 1 and prop.iloc[0]["confidence"] > 0.85:
-                    name_label = prop.iloc[0]["label"]
-
-            pitem = {
-                "text": text,
-                "name": name_label,  # pelem["name"],
-                "type": type_label,  # pelem["type"],
-                "prov": [
-                    {
-                        "bbox": pelem["bbox"],
-                        "page": pelem["page"],
-                        "span": [0, len(text)],
-                    }
-                ],
-            }
-            doc_leg["main-text"].append(pitem)
-
-        else:
-            pitem = {
-                "name": pelem["name"],
-                "type": pelem["type"],
-                "prov": [
-                    {"bbox": pelem["bbox"], "page": pelem["page"], "span": [0, 0]}
-                ],
-            }
-            doc_leg["main-text"].append(pitem)
-
-    return doc_leg
-
-
-def to_xml_format(doc_glm, normalised_pagedim: int = -1):
-    result = "<document>\n"
-
-    page_dims = pd.DataFrame()
-    if "page-dimensions":
-        page_dims = pd.DataFrame(doc_glm["page-dimensions"])
-
-    for pelem in doc_glm["page-elements"]:
-        ptype = pelem["type"]
-        span_i = pelem["span"][0]
-        span_j = pelem["span"][1]
-
-        if "iref" not in pelem:
-            # print(json.dumps(pelem, indent=2))
-            continue
-
-        iref = pelem["iref"]
-
-        page = pelem["page"]
-        bbox = pelem["bbox"]
-
-        x0 = bbox[0]
-        y0 = bbox[1]
-        x1 = bbox[2]
-        y1 = bbox[3]
-
-        if normalised_pagedim > 0 and len(page_dims[page_dims["page"] == page]) > 0:
-            page_width = page_dims[page_dims["page"] == page].iloc[0]["width"]
-            page_height = page_dims[page_dims["page"] == page].iloc[0]["height"]
-
-            rx0 = float(x0) / float(page_width) * normalised_pagedim
-            rx1 = float(x1) / float(page_width) * normalised_pagedim
-
-            ry0 = float(y0) / float(page_height) * normalised_pagedim
-            ry1 = float(y1) / float(page_height) * normalised_pagedim
-
-            x0 = max(0, min(normalised_pagedim, round(rx0)))
-            x1 = max(0, min(normalised_pagedim, round(rx1)))
-
-            y0 = max(0, min(normalised_pagedim, round(ry0)))
-            y1 = max(0, min(normalised_pagedim, round(ry1)))
-
-        elif normalised_pagedim > 0 and len(page_dims[page_dims["page"] == page]) == 0:
-            print(f"ERROR: no page dimensions for page {page}")
-
-        if re.match("#/figures/(\\d+)/captions/(.+)", iref):
-            # print(f"skip {iref}")
-            continue
-
-        if re.match("#/tables/(\\d+)/captions/(.+)", iref):
-            # print(f"skip {iref}")
-            continue
-
-        path = iref.split("/")
-        obj = resolve_item(path, doc_glm)
-
-        if obj is None:
-            print(f"warning: undefined {path}")
-            continue
-
-        if ptype == "figure":
-            result += f"<figure bbox=[{x0}, {y0}, {x1}, {y1}]></figure>\n"
-
-        elif ptype == "table":
-            result += f"<table bbox=[{x0}, {y0}, {x1}, {y1}]></table>\n"
-
-        elif "text" in obj:
-            text = obj["text"][span_i:span_j]
-            text_type = pelem["type"]
-
-            result += (
-                f"<{text_type} bbox=[{x0}, {y0}, {x1}, {y1}]>{text}</{text_type}>\n"
-            )
-        else:
-            continue
-
-    result += "</document>"
-
-    return result

--- a/poetry.lock
+++ b/poetry.lock
@@ -1875,13 +1875,13 @@ files = [
 
 [[package]]
 name = "tqdm"
-version = "4.66.2"
+version = "4.66.5"
 description = "Fast, Extensible Progress Meter"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "tqdm-4.66.2-py3-none-any.whl", hash = "sha256:1ee4f8a893eb9bef51c6e35730cebf234d5d0b6bd112b0271e10ed7c24a02bd9"},
-    {file = "tqdm-4.66.2.tar.gz", hash = "sha256:6cd52cdf0fef0e0f543299cfc96fec90d7b8a7e88745f411ec33eb44d5ed3531"},
+    {file = "tqdm-4.66.5-py3-none-any.whl", hash = "sha256:90279a3770753eafc9194a0364852159802111925aa30eb3f9d85b0e805ac7cd"},
+    {file = "tqdm-4.66.5.tar.gz", hash = "sha256:e1020aef2e5096702d8a025ac7d16b1577279c9d63f8375b63083e9a5f0fcbad"},
 ]
 
 [package.dependencies]
@@ -2010,4 +2010,4 @@ toolkit = ["deepsearch-toolkit"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "c20a01b4c862c091870e316db5031d7be1acb97fc1d18e3ce5c9dfa38050e8d6"
+content-hash = "d83189d440d74ef4ba67d125f2fc176ae247e2ed841c6d9095ef40ebde68e970"

--- a/poetry.lock
+++ b/poetry.lock
@@ -784,7 +784,7 @@ attrs = "*"
 name = "markdown-it-py"
 version = "3.0.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
-optional = true
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"},
@@ -887,7 +887,7 @@ files = [
 name = "mdurl"
 version = "0.1.2"
 description = "Markdown URL utilities"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
@@ -1454,7 +1454,7 @@ typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 name = "pygments"
 version = "2.17.2"
 description = "Pygments is a syntax highlighting package written in Python."
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "pygments-2.17.2-py3-none-any.whl", hash = "sha256:b27c2826c47d0f3219f29554824c30c5e8945175d888647acd804ddd04af846c"},
@@ -1653,13 +1653,13 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "rich"
-version = "13.7.0"
+version = "13.8.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
-optional = true
+optional = false
 python-versions = ">=3.7.0"
 files = [
-    {file = "rich-13.7.0-py3-none-any.whl", hash = "sha256:6da14c108c4866ee9520bbffa71f6fe3962e193b7da68720583850cd4548e235"},
-    {file = "rich-13.7.0.tar.gz", hash = "sha256:5cb5123b5cf9ee70584244246816e9114227e0b98ad9176eede6ad54bf5403fa"},
+    {file = "rich-13.8.0-py3-none-any.whl", hash = "sha256:2e85306a063b9492dffc86278197a60cbece75bcb766022f3436f567cae11bdc"},
+    {file = "rich-13.8.0.tar.gz", hash = "sha256:a5ac1f1cd448ade0d59cc3356f7db7a7ccda2c8cbae9c7a90c28ff463d3e91f4"},
 ]
 
 [package.dependencies]
@@ -1828,17 +1828,6 @@ files = [
 
 [package.extras]
 widechars = ["wcwidth"]
-
-[[package]]
-name = "textcolor"
-version = "3.1.0"
-description = "This is an easy to use Python library which allows you to make your terminal outputs more colorful and therefore easier to read and understand"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "textcolor-3.1.0-py3-none-any.whl", hash = "sha256:9b91cf4f1d2c3e4f1bc3970d034572c64bb2268a92b84ad72c6344dcae702649"},
-    {file = "textcolor-3.1.0.tar.gz", hash = "sha256:5be1df153efccede3e6976e9c4de49c3df900117e3f6227bc6a0e5e57ff99a5b"},
-]
 
 [[package]]
 name = "toml"
@@ -2010,4 +1999,4 @@ toolkit = ["deepsearch-toolkit"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "d83189d440d74ef4ba67d125f2fc176ae247e2ed841c6d9095ef40ebde68e970"
+content-hash = "10986e6a3327885e206b902759aaaa61fead5dd6e63edb23a4b0e3f92084ec96"

--- a/poetry.lock
+++ b/poetry.lock
@@ -15,7 +15,7 @@ files = [
 name = "annotated-types"
 version = "0.6.0"
 description = "Reusable constraint types to use with typing.Annotated"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "annotated_types-0.6.0-py3-none-any.whl", hash = "sha256:0641064de18ba7a25dee8f96403ebc39113d0cb953a01429249d5c7564666a43"},
@@ -166,7 +166,7 @@ files = [
 name = "charset-normalizer"
 version = "3.3.2"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
-optional = false
+optional = true
 python-versions = ">=3.7.0"
 files = [
     {file = "charset-normalizer-3.3.2.tar.gz", hash = "sha256:f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"},
@@ -407,7 +407,7 @@ tests = ["pytest", "pytest-cov", "pytest-xdist"]
 name = "deepsearch-toolkit"
 version = "0.40.0"
 description = "Interact with the Deep Search platform for new knowledge explorations and discoveries"
-optional = false
+optional = true
 python-versions = ">=3.8,<4.0"
 files = [
     {file = "deepsearch_toolkit-0.40.0-py3-none-any.whl", hash = "sha256:22044e13319bcb189672cbd06cb4115ab4c99fcd4e994de862c031c909f7854f"},
@@ -589,7 +589,7 @@ license = ["ukkonen"]
 name = "idna"
 version = "3.6"
 description = "Internationalized Domain Names in Applications (IDNA)"
-optional = false
+optional = true
 python-versions = ">=3.5"
 files = [
     {file = "idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"},
@@ -784,7 +784,7 @@ attrs = "*"
 name = "markdown-it-py"
 version = "3.0.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"},
@@ -887,7 +887,7 @@ files = [
 name = "mdurl"
 version = "0.1.2"
 description = "Markdown URL utilities"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
@@ -1344,7 +1344,7 @@ global = ["pybind11-global (==2.11.1)"]
 name = "pydantic"
 version = "2.6.1"
 description = "Data validation using Python type hints"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "pydantic-2.6.1-py3-none-any.whl", hash = "sha256:0b6a909df3192245cb736509a92ff69e4fef76116feffec68e93a567347bae6f"},
@@ -1363,7 +1363,7 @@ email = ["email-validator (>=2.0.0)"]
 name = "pydantic-core"
 version = "2.16.2"
 description = ""
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "pydantic_core-2.16.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:3fab4e75b8c525a4776e7630b9ee48aea50107fea6ca9f593c98da3f4d11bf7c"},
@@ -1454,7 +1454,7 @@ typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 name = "pygments"
 version = "2.17.2"
 description = "Pygments is a syntax highlighting package written in Python."
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "pygments-2.17.2-py3-none-any.whl", hash = "sha256:b27c2826c47d0f3219f29554824c30c5e8945175d888647acd804ddd04af846c"},
@@ -1634,7 +1634,7 @@ files = [
 name = "requests"
 version = "2.31.0"
 description = "Python HTTP for Humans."
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
@@ -1655,7 +1655,7 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 name = "rich"
 version = "13.7.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
-optional = false
+optional = true
 python-versions = ">=3.7.0"
 files = [
     {file = "rich-13.7.0-py3-none-any.whl", hash = "sha256:6da14c108c4866ee9520bbffa71f6fe3962e193b7da68720583850cd4548e235"},
@@ -1690,7 +1690,7 @@ testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jar
 name = "shellingham"
 version = "1.5.4"
 description = "Tool to Detect Surrounding Shell"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
@@ -1877,7 +1877,7 @@ files = [
 name = "tqdm"
 version = "4.66.2"
 description = "Fast, Extensible Progress Meter"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "tqdm-4.66.2-py3-none-any.whl", hash = "sha256:1ee4f8a893eb9bef51c6e35730cebf234d5d0b6bd112b0271e10ed7c24a02bd9"},
@@ -1897,7 +1897,7 @@ telegram = ["requests"]
 name = "typer"
 version = "0.9.0"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
-optional = false
+optional = true
 python-versions = ">=3.6"
 files = [
     {file = "typer-0.9.0-py3-none-any.whl", hash = "sha256:5d96d986a21493606a358cae4461bd8cdf83cbf33a5aa950ae629ca3b51467ee"},
@@ -1943,7 +1943,7 @@ files = [
 name = "urllib3"
 version = "1.26.18"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 files = [
     {file = "urllib3-1.26.18-py2.py3-none-any.whl", hash = "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07"},
@@ -2004,7 +2004,10 @@ files = [
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
 
+[extras]
+toolkit = ["deepsearch-toolkit"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "ccc3c03a45f9aa4fddbac49bd773cbde06287227d045661c44718e3b6e68e2dc"
+content-hash = "c20a01b4c862c091870e316db5031d7be1acb97fc1d18e3ce5c9dfa38050e8d6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ build = "build.py"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-deepsearch-toolkit = ">=0.31.0"
+deepsearch-toolkit = { version = ">=0.31.0", optional = true }
 textColor = "^3.0.1"
 tabulate = ">=0.8.9"
 numpy = [
@@ -42,6 +42,14 @@ cibuildwheel = "^2.19.2"
 wheel = "^0.43.0"
 delocate = "^0.11.0"
 
+[tool.poetry.extras]
+# MANUAL MAINTENANCE REQUIRED: for every change in the extras, "all" must be updated,
+# namely as the union of all extras' direct dependencies (since poetry currently does not
+# support recursive extras: https://github.com/python-poetry/poetry/issues/3369)
+
+toolkit = ["deepsearch-toolkit"]
+
+
 [tool.black]
 line-length = 88
 target-version = ["py38"]
@@ -59,7 +67,7 @@ py_version=38
 #known_first_party = ["cps"]
 
 [tool.mypy]
-plugins = ["pydantic.mypy"]
+# plugins = ["pydantic.mypy"]
 pretty = true
 # strict = true
 #no_implicit_optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ netwulf = "^0.1.5"
 python-dotenv = "^1.0.0"
 pybind11 = "^2.10.4"
 numerize = "^0.12"
+tqdm = "^4.64.0"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.4.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ build = "build.py"
 [tool.poetry.dependencies]
 python = "^3.8"
 deepsearch-toolkit = { version = ">=0.31.0", optional = true }
-textColor = "^3.0.1"
 tabulate = ">=0.8.9"
 numpy = [
     { version = "^1.26.4", markers = 'python_version >= "3.9"' },
@@ -29,6 +28,7 @@ python-dotenv = "^1.0.0"
 pybind11 = "^2.10.4"
 numerize = "^0.12"
 tqdm = "^4.64.0"
+rich = "^13.7.0"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.4.2"
@@ -93,10 +93,6 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "tqdm.*"
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = "textColor.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/tests/test_nlp.py
+++ b/tests/test_nlp.py
@@ -23,7 +23,7 @@ from deepsearch_glm.nlp_utils import (
     train_fst,
     train_tok,
 )
-from deepsearch_glm.utils.ds_utils import to_legacy_document_format
+from deepsearch_glm.utils.doc_utils import to_legacy_document_format
 from deepsearch_glm.utils.load_pretrained_models import (  # load_pretrained_nlp_data,
     get_resources_dir,
     list_training_data,


### PR DESCRIPTION
With this simple refactoring, the main GLM functions used by [Docling](https://github.com/DS4SD/docling) don't depend on [deepsearch-toolkit](https://github.com/DS4SD/deepsearch-toolkit).

Initial testing shows that this is completely backwards compatible (assuming the toolkit is installed).

Additionally, we also remove the `textcolor` GPL dependency.