### PR TITLE
ci: enable ppc64le wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -110,7 +110,7 @@ jobs:
           CIBW_ARCHS: x86_64
           CIBW_ARCHS_MACOS: x86_64
           CIBW_PLATFORM: macos
-          CIBW_SKIP: "pp* *-musllinux_* *_i686* *_s390* *arm64* *pypy*"
+          CIBW_SKIP: "pp* *-musllinux_* *_i686* *_s390* *ppc64le* *arm64* *pypy*"
           CIBW_PROJECT_REQUIRES_PYTHON: "~=${{ matrix.python-version }}.0"
           CIBW_BUILD_VERBOSITY: 3
           CMAKE_OSX_ARCHITECTURES: x86_64
@@ -211,7 +211,7 @@ jobs:
         if: startsWith(matrix.os.name, 'ubuntu')
         env:
           # CIBW_BUILD: ${{ env.python_cp_version }}-${{ matrix.os.platform_id }}
-          CIBW_ARCHS: auto x86_64 aarch64
+          CIBW_ARCHS: auto x86_64 aarch64 ppc64le
           CIBW_PLATFORM: linux
           CIBW_SKIP: "pp* *musllinux_* *_i686* *_s390* *pypy*"
           CIBW_PROJECT_REQUIRES_PYTHON: "~=${{ matrix.python-version }}.0"


### PR DESCRIPTION
This PR enables building ppc64le manylinux wheels on GitHub Actions. It does not introduce any content changes.